### PR TITLE
Numpy ABI updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ with open(os.path.join(here, 'README.rst')) as f:
 
 StisPixCteCorr_module = Extension('stis_cti.StisPixCte_FixY',
     sources=['src/StisFixYCte.c', 'src/StisPixCteCorr_funcs.c', 'src/StisPixCte_FixY.c'],
-    include_dirs=[numpy.get_include(), 'src/'])
+    include_dirs=[numpy.get_include(), 'src/'],
+    define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],)
 
 setup(
     name = 'stis_cti',

--- a/src/StisPixCteCorr.h
+++ b/src/StisPixCteCorr.h
@@ -19,7 +19,7 @@
 /* function prototypes */
 double CalcCteFrac(const double expstart, const double scalemjd[NUM_SCALE],
                    const double scaleval[NUM_SCALE]);
-int InterpolatePsi(const double chg_leak[NUM_PSI*NUM_LOGQ], const int psi_node[],
+int InterpolatePsi(const double chg_leak[NUM_PSI*NUM_LOGQ], const int psi_node[NUM_PSI],
                    double chg_leak_interp[MAX_TAIL_LEN*NUM_LOGQ],
                    double chg_open_interp[MAX_TAIL_LEN*NUM_LOGQ]);
 int InterpolatePhi(const double dtde_l[NUM_PHI], const int q_dtde[NUM_PHI],

--- a/src/StisPixCte_FixY.c
+++ b/src/StisPixCte_FixY.c
@@ -21,9 +21,9 @@ static PyObject * py_CalcCteFrac(PyObject *self, PyObject *args) {
   }
   
   py_scale_mjd = (PyArrayObject *) PyArray_FROMANY(opy_scale_mjd, NPY_DOUBLE, 
-                                                    1, 1, NPY_IN_ARRAY);
+                                                    1, 1, NPY_ARRAY_IN_ARRAY);
   py_scale_val = (PyArrayObject *) PyArray_FROMANY(opy_scale_val, NPY_DOUBLE, 
-                                                    1, 1, NPY_IN_ARRAY);
+                                                    1, 1, NPY_ARRAY_IN_ARRAY);
   
   /* get cte_frac */
   cte_frac = CalcCteFrac(mjd, (double *) PyArray_DATA(py_scale_mjd),
@@ -65,8 +65,8 @@ static PyObject * py_InterpolatePsi(PyObject *self, PyObject *args) {
     return NULL;
   }
   
-  py_psi_node = (PyArrayObject *) PyArray_FROMANY(opy_psi_node, NPY_INT, 1, 1, NPY_IN_ARRAY);
-  py_chg_leak = (PyArrayObject *) PyArray_FROMANY(opy_chg_leak, NPY_DOUBLE, 2, 2, NPY_IN_ARRAY);
+  py_psi_node = (PyArrayObject *) PyArray_FROMANY(opy_psi_node, NPY_INT, 1, 1, NPY_ARRAY_IN_ARRAY);
+  py_chg_leak = (PyArrayObject *) PyArray_FROMANY(opy_chg_leak, NPY_DOUBLE, 2, 2, NPY_ARRAY_IN_ARRAY);
   if (!py_psi_node || !py_chg_leak) {
     return NULL;
   }
@@ -110,8 +110,8 @@ static PyObject * py_InterpolatePhi(PyObject *self, PyObject *args) {
     return NULL;
   }
    
-  py_dtde_l = (PyArrayObject *) PyArray_FROMANY(opy_dtde_l, NPY_DOUBLE, 1, 1, NPY_IN_ARRAY);
-  py_q_dtde = (PyArrayObject *) PyArray_FROMANY(opy_q_dtde, NPY_INT, 1, 1, NPY_IN_ARRAY);
+  py_dtde_l = (PyArrayObject *) PyArray_FROMANY(opy_dtde_l, NPY_DOUBLE, 1, 1, NPY_ARRAY_IN_ARRAY);
+  py_q_dtde = (PyArrayObject *) PyArray_FROMANY(opy_q_dtde, NPY_INT, 1, 1, NPY_ARRAY_IN_ARRAY);
   if (!py_dtde_l || !py_q_dtde) {
     return NULL;
   }
@@ -160,11 +160,11 @@ static PyObject * py_FillLevelArrays(PyObject *self, PyObject *args) {
   }
   
   py_chg_leak_kt = 
-    (PyArrayObject *) PyArray_FROMANY(opy_chg_leak_kt, NPY_DOUBLE, 2, 2, NPY_IN_ARRAY);
+    (PyArrayObject *) PyArray_FROMANY(opy_chg_leak_kt, NPY_DOUBLE, 2, 2, NPY_ARRAY_IN_ARRAY);
   py_chg_open_kt = 
-    (PyArrayObject *) PyArray_FROMANY(opy_chg_open_kt, NPY_DOUBLE, 2, 2, NPY_IN_ARRAY);
-  py_dtde_q = (PyArrayObject *) PyArray_FROMANY(opy_dtde_q, NPY_DOUBLE, 1, 1, NPY_IN_ARRAY);
-  py_levels = (PyArrayObject *) PyArray_FROMANY(opy_levels, NPY_INT, 1, 1, NPY_IN_ARRAY);
+    (PyArrayObject *) PyArray_FROMANY(opy_chg_open_kt, NPY_DOUBLE, 2, 2, NPY_ARRAY_IN_ARRAY);
+  py_dtde_q = (PyArrayObject *) PyArray_FROMANY(opy_dtde_q, NPY_DOUBLE, 1, 1, NPY_ARRAY_IN_ARRAY);
+  py_levels = (PyArrayObject *) PyArray_FROMANY(opy_levels, NPY_INT, 1, 1, NPY_ARRAY_IN_ARRAY);
   if (!py_chg_leak_kt || !py_chg_open_kt || !py_dtde_q || !py_levels) {
     return NULL;
   }
@@ -212,14 +212,14 @@ static PyObject * py_DecomposeRN(PyObject *self, PyObject *args) {
     return NULL;
   }
   
-  py_data = (PyArrayObject *) PyArray_FROMANY(opy_data, NPY_DOUBLE, 2, 2, NPY_IN_ARRAY);
+  py_data = (PyArrayObject *) PyArray_FROMANY(opy_data, NPY_DOUBLE, 2, 2, NPY_ARRAY_IN_ARRAY);
   if (!py_data) {
     return NULL;
   }
   
   /* assign/allocate local variables */
-  arrx = py_data->dimensions[0];
-  arry = py_data->dimensions[1];
+  arrx = PyArray_DIMS(py_data)[0];
+  arry = PyArray_DIMS(py_data)[1];
   
   /* return variables */
   out_dim = (npy_intp *) malloc(2 * sizeof(npy_intp));
@@ -273,25 +273,25 @@ static PyObject * py_FixYCte(PyObject *self, PyObject *args) {
   }
   
   py_sig_cte = (PyArrayObject *) PyArray_FROMANY(opy_sig_cte, NPY_DOUBLE,
-                                                 2, 2, NPY_IN_ARRAY);
+                                                 2, 2, NPY_ARRAY_IN_ARRAY);
   py_cte_frac = (PyArrayObject *) PyArray_FROMANY(opy_cte_frac, NPY_DOUBLE,
-                                                  2, 2, NPY_IN_ARRAY);
+                                                  2, 2, NPY_ARRAY_IN_ARRAY);
   py_levels = (PyArrayObject *) PyArray_FROMANY(opy_levels, NPY_INT,
-                                                1, 1, NPY_IN_ARRAY);
+                                                1, 1, NPY_ARRAY_IN_ARRAY);
   py_dpde_l = (PyArrayObject *) PyArray_FROMANY(opy_dpde_l, NPY_DOUBLE,
-                                                1, 1, NPY_IN_ARRAY);
+                                                1, 1, NPY_ARRAY_IN_ARRAY);
   py_chg_leak_lt = (PyArrayObject *) PyArray_FROMANY(opy_chg_leak_lt, NPY_DOUBLE, 
-                                                     2, 2, NPY_IN_ARRAY);
+                                                     2, 2, NPY_ARRAY_IN_ARRAY);
   py_chg_open_lt = (PyArrayObject *) PyArray_FROMANY(opy_chg_open_lt, NPY_DOUBLE, 
-                                                     2, 2, NPY_IN_ARRAY);
+                                                     2, 2, NPY_ARRAY_IN_ARRAY);
   if (!py_sig_cte || !py_cte_frac || !py_levels || !py_dpde_l || 
       !py_chg_leak_lt || !py_chg_open_lt) {
     return NULL;
   }
   
   /* local variables */
-  arrx = py_sig_cte->dimensions[0];
-  arry = py_sig_cte->dimensions[1];
+  arrx = PyArray_DIMS(py_sig_cte)[0];
+  arry = PyArray_DIMS(py_sig_cte)[1];
   
   /* return variables */
   out_dim = (npy_intp *) malloc(2 * sizeof(npy_intp));
@@ -352,25 +352,25 @@ static PyObject * py_AddYCte(PyObject *self, PyObject *args) {
   }
   
   py_sig_cte = (PyArrayObject *) PyArray_FROMANY(opy_sig_cte, NPY_DOUBLE,
-                                                 2, 2, NPY_IN_ARRAY);
+                                                 2, 2, NPY_ARRAY_IN_ARRAY);
   py_cte_frac = (PyArrayObject *) PyArray_FROMANY(opy_cte_frac, NPY_DOUBLE,
-                                                  2, 2, NPY_IN_ARRAY);
+                                                  2, 2, NPY_ARRAY_IN_ARRAY);
   py_levels = (PyArrayObject *) PyArray_FROMANY(opy_levels, NPY_INT,
-                                                1, 1, NPY_IN_ARRAY);
+                                                1, 1, NPY_ARRAY_IN_ARRAY);
   py_dpde_l = (PyArrayObject *) PyArray_FROMANY(opy_dpde_l, NPY_DOUBLE,
-                                                1, 1, NPY_IN_ARRAY);
+                                                1, 1, NPY_ARRAY_IN_ARRAY);
   py_chg_leak_lt = (PyArrayObject *) PyArray_FROMANY(opy_chg_leak_lt, NPY_DOUBLE, 
-                                                     2, 2, NPY_IN_ARRAY);
+                                                     2, 2, NPY_ARRAY_IN_ARRAY);
   py_chg_open_lt = (PyArrayObject *) PyArray_FROMANY(opy_chg_open_lt, NPY_DOUBLE, 
-                                                     2, 2, NPY_IN_ARRAY);
+                                                     2, 2, NPY_ARRAY_IN_ARRAY);
   if (!py_sig_cte || !py_cte_frac || !py_levels || !py_dpde_l || 
       !py_chg_leak_lt || !py_chg_open_lt) {
     return NULL;
   }
   
   /* local variables */
-  arrx = py_sig_cte->dimensions[0];
-  arry = py_sig_cte->dimensions[1];
+  arrx = PyArray_DIMS(py_sig_cte)[0];
+  arry = PyArray_DIMS(py_sig_cte)[1];
   
   /* return variables */
   out_dim = (npy_intp *) malloc(2 * sizeof(npy_intp));


### PR DESCRIPTION
Manually tested by deleting old `build/*` directories, recompiling (`python ./setup.py build`), and installing (`pip install .`).

Used both `numpy 2.0.0rc1` + `astropy 6.1.0rc1`.  Resulting corrected data was numerically identical (via `fitsdiff`).  Also checked in older `numpy 1.24.3` + `astropy 5.3.3` environment.